### PR TITLE
Fix error throwing in summarizeStreaming()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -620,11 +620,11 @@ The <dfn attribute for="AISummarizer">length</dfn> getter steps are to return [=
 <div algorithm>
   The <dfn method for="AISummarizer">summarizeStreaming(|input|, |options|)</dfn> method steps are:
 
-  1. If [=this=]'s [=relevant global object=] is a {{Window}} whose [=associated Document=] is not [=Document/fully active=], then return [=a promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.
+  1. If [=this=]'s [=relevant global object=] is a {{Window}} whose [=associated Document=] is not [=Document/fully active=], then throw an "{{InvalidStateError}}" {{DOMException}}.
 
-  1. If [=this=]'s [=AISummarizer/destroyed=] is true, then return [=a promise rejected with=] [=this=]'s [=AISummarizer/destruction reason=].
+  1. If [=this=]'s [=AISummarizer/destroyed=] is true, then throw [=this=]'s [=AISummarizer/destruction reason=].
 
-  1. If |options|["{{AISummarizerSummarizeOptions/signal}}"] [=map/exists=] and is [=AbortSignal/aborted=], then return [=a promise rejected with=] |options|["{{AISummarizerSummarizeOptions/signal}}"]'s [=AbortSignal/abort reason=].
+  1. If |options|["{{AISummarizerSummarizeOptions/signal}}"] [=map/exists=] and is [=AbortSignal/aborted=], then throw |options|["{{AISummarizerSummarizeOptions/signal}}"]'s [=AbortSignal/abort reason=].
 
   1. Let |abortedDuringSummarization| be false.
 


### PR DESCRIPTION
Previously it was returning rejected promises, but this method does not return promises, so it should throw the exceptions instead.

I considered instead returning an immediately-errored ReadableStream. This seems a bit nicer, but a lot of precedent on the web platform points toward throwing. (Actually, most precedent is for methods returning a promise for a ReadableStream, and returning a rejected promise. I cannot find any methods that currently return a ReadableStream synchronously. But throwing is the sync analogue of returning a rejected promise.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/pull/27.html" title="Last updated on Jan 16, 2025, 3:25 AM UTC (ebf194b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/27/8afcced...ebf194b.html" title="Last updated on Jan 16, 2025, 3:25 AM UTC (ebf194b)">Diff</a>