### PR TITLE
Improve download progress firing algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -867,8 +867,6 @@ enum AIRewriterLength { "as-is", "shorter", "longer" };
 
           1. Perform |fireProgressEvent| given 0.
 
-          1. Wait for at least one byte to be downloaded, or for downloading to fail.
-
           1. While true:
 
             1. If downloading has failed, then:
@@ -879,7 +877,7 @@ enum AIRewriterLength { "as-is", "shorter", "longer" };
 
             1. Let |bytesSoFar| be the number of bytes downloaded so far.
 
-            1. [=Assert=]: |bytesSoFar| is greater than 0 and less than or equal to |totalBytes|.
+            1. [=Assert=]: |bytesSoFar| is greater than or equal to 0, and less than or equal to |totalBytes|.
 
             1. If the [=monotonic clock=]'s [=monotonic clock/unsafe current time=] minus |lastProgressTime| is greater than 50 ms, or |bytesSoFar| equals |totalBytes|, then:
 
@@ -980,7 +978,7 @@ enum AIRewriterLength { "as-is", "shorter", "longer" };
 
               1. If |bytesSoFar| equals |totalBytes|, then [=iteration/break=].
 
-                <p class="note">Since this is the only exit condition for the loop, we are guaranteed to fire a {{AICreateMonitor/downloadprogress}} event for the 100% mark.</p>
+                <p class="note">Since this is the only non-failure exit condition for the loop, we will never miss firing a {{AICreateMonitor/downloadprogress}} event for the 100% mark.</p>
 
               1. Set |lastProgressFraction| to |progressFraction|.
 

--- a/index.bs
+++ b/index.bs
@@ -861,126 +861,130 @@ enum AIRewriterLength { "as-is", "shorter", "longer" };
 
           1. Wait for the total number of bytes to be downloaded to become determined, and let that number be |totalBytes|.
 
+          1. Let |lastProgressFraction| be 0.
+
           1. Let |lastProgressTime| be the [=monotonic clock=]'s [=monotonic clock/unsafe current time=].
 
           1. Perform |fireProgressEvent| given 0.
 
+          1. Wait for at least one byte to be downloaded, or for downloading to fail.
+
           1. While true:
 
-            1. If one or more bytes have been downloaded, then:
-
-              1. If the [=monotonic clock=]'s [=monotonic clock/unsafe current time=] minus |lastProgressTime| is greater than 50 ms, then:
-
-                1. Let |bytesSoFar| be the number of bytes downloaded so far.
-
-                1. [=Assert=]: |bytesSoFar| is greater than 0 and less than or equal to |totalBytes|.
-
-                1. Let |rawProgressFraction| be |bytesSoFar| divided by |totalBytes|.
-
-                1. Let |progressFraction| be [$floor$](|rawProgressFraction| &times; 65,536) &divide; 65,536.
-
-                1. Perform |fireProgressEvent| given |progressFraction|.
-
-                   <div class="note">
-                    <p>We use a fraction, instead of firing a progress event with the number of bytes downloaded, to avoid giving precise information about the size of the model or other material being downloaded.</p>
-
-                    <p>|progressFraction| is calculated from |rawProgressFraction| to give a precision of one part in 2<sup>16</sup>. This ensures that over most internet speeds and with most model sizes, the {{ProgressEvent/loaded}} value will be different from the previous one that was fired ~50 milliseconds ago.</p>
-
-                    <details>
-                      <summary>Full calculation</summary>
-
-                      <p>Assume a 5 GiB download size, and a 20 Mbps download speed (chosen as a number on the lower range from [this source](https://worldpopulationreview.com/country-rankings/internet-speeds-by-country)). Then, downloading 5 GiB will take:</p>
-
-                      <math style="display:block math">
-                        <mtable>
-                          <mtr>
-                            <mtd></mtd>
-                            <mtd style="text-align: left">
-                              <mn>5</mn>
-                              <mtext>&nbsp;GiB</mtext>
-
-                              <mo>×</mo>
-                              <mfrac>
-                                <mrow>
-                                  <msup>
-                                    <mn>2</mn>
-                                    <mn>30</mn>
-                                  </msup>
-                                  <mtext>&nbsp;bytes</mtext>
-                                </mrow>
-                                <mtext>GiB</mtext>
-                              </mfrac>
-
-                              <mo>×</mo>
-                              <mfrac>
-                                <mrow>
-                                  <mn>8</mn>
-                                  <mtext>&nbsp;bits</mtext>
-                                </mrow>
-                                <mtext>bytes</mtext>
-                              </mfrac>
-
-                              <mo>÷</mo>
-                              <mfrac>
-                                <mrow>
-                                  <mn>20</mn>
-                                  <mo>×</mo>
-                                  <msup>
-                                    <mn>10</mn>
-                                    <mn>6</mn>
-                                  </msup>
-                                  <mtext>&nbsp;bits</mtext>
-                                </mrow>
-                                <mtext>s</mtext>
-                              </mfrac>
-
-                              <mo>×</mo>
-                              <mfrac>
-                                <mrow>
-                                  <mn>1000</mn>
-                                  <mtext>&nbsp;ms</mtext>
-                                </mrow>
-                                <mtext>s</mtext>
-                              </mfrac>
-
-                              <mo>÷</mo>
-                              <mfrac>
-                                <mrow>
-                                  <mn>50</mn>
-                                  <mtext>&nbsp;ms</mtext>
-                                </mrow>
-                                <mtext>interval</mtext>
-                              </mfrac>
-                            </mtd>
-                          </mtr>
-
-                          <mtr>
-                            <mtd>
-                              <mo>=</mo>
-                            </mtd>
-                            <mtd style="text-align: left">
-                              <mn>49,950</mn>
-                              <mtext>&nbsp;intervals</mtext>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </math>
-
-                      Rounding up to the nearest power of two gives a conservative estimate of 65,536 fifty millisecond intervals, so we want to give progress to 1 part in 2<sup>16</sup>.
-                    </details>
-                  </div>
-
-                1. If |bytesSoFar| equals |totalBytes|, then [=iteration/break=].
-
-                  <p class="note">Since this is the only exit condition for the loop, we are guaranteed to fire a {{AICreateMonitor/downloadprogress}} event for the 100% mark.</p>
-
-                1. Set |lastProgressTime| to the [=monotonic clock=]'s [=monotonic clock/unsafe current time=].
-
-            1. Otherwise, if downloading has failed and cannot continue, then:
+            1. If downloading has failed, then:
 
               1. [=Queue a global task=] on the [=AI task source=] given |realm|'s [=realm/global object=] to [=reject=] |promise| with a "{{NetworkError}}" {{DOMException}}.
 
               1. Abort these steps.
+
+            1. Let |bytesSoFar| be the number of bytes downloaded so far.
+
+            1. [=Assert=]: |bytesSoFar| is greater than 0 and less than or equal to |totalBytes|.
+
+            1. If the [=monotonic clock=]'s [=monotonic clock/unsafe current time=] minus |lastProgressTime| is greater than 50 ms, or |bytesSoFar| equals |totalBytes|, then:
+
+              1. Let |rawProgressFraction| be |bytesSoFar| divided by |totalBytes|.
+
+              1. Let |progressFraction| be [$floor$](|rawProgressFraction| &times; 65,536) &divide; 65,536.
+
+                  <div class="note">
+                  <p>We use a fraction, instead of firing a progress event with the number of bytes downloaded, to avoid giving precise information about the size of the model or other material being downloaded.</p>
+
+                  <p>|progressFraction| is calculated from |rawProgressFraction| to give a precision of one part in 2<sup>16</sup>. This ensures that over most internet speeds and with most model sizes, the {{ProgressEvent/loaded}} value will be different from the previous one that was fired ~50 milliseconds ago.</p>
+
+                  <details>
+                    <summary>Full calculation</summary>
+
+                    <p>Assume a 5 GiB download size, and a 20 Mbps download speed (chosen as a number on the lower range from [this source](https://worldpopulationreview.com/country-rankings/internet-speeds-by-country)). Then, downloading 5 GiB will take:</p>
+
+                    <math style="display:block math">
+                      <mtable>
+                        <mtr>
+                          <mtd></mtd>
+                          <mtd style="text-align: left">
+                            <mn>5</mn>
+                            <mtext>&nbsp;GiB</mtext>
+
+                            <mo>×</mo>
+                            <mfrac>
+                              <mrow>
+                                <msup>
+                                  <mn>2</mn>
+                                  <mn>30</mn>
+                                </msup>
+                                <mtext>&nbsp;bytes</mtext>
+                              </mrow>
+                              <mtext>GiB</mtext>
+                            </mfrac>
+
+                            <mo>×</mo>
+                            <mfrac>
+                              <mrow>
+                                <mn>8</mn>
+                                <mtext>&nbsp;bits</mtext>
+                              </mrow>
+                              <mtext>bytes</mtext>
+                            </mfrac>
+
+                            <mo>÷</mo>
+                            <mfrac>
+                              <mrow>
+                                <mn>20</mn>
+                                <mo>×</mo>
+                                <msup>
+                                  <mn>10</mn>
+                                  <mn>6</mn>
+                                </msup>
+                                <mtext>&nbsp;bits</mtext>
+                              </mrow>
+                              <mtext>s</mtext>
+                            </mfrac>
+
+                            <mo>×</mo>
+                            <mfrac>
+                              <mrow>
+                                <mn>1000</mn>
+                                <mtext>&nbsp;ms</mtext>
+                              </mrow>
+                              <mtext>s</mtext>
+                            </mfrac>
+
+                            <mo>÷</mo>
+                            <mfrac>
+                              <mrow>
+                                <mn>50</mn>
+                                <mtext>&nbsp;ms</mtext>
+                              </mrow>
+                              <mtext>interval</mtext>
+                            </mfrac>
+                          </mtd>
+                        </mtr>
+
+                        <mtr>
+                          <mtd>
+                            <mo>=</mo>
+                          </mtd>
+                          <mtd style="text-align: left">
+                            <mn>49,950</mn>
+                            <mtext>&nbsp;intervals</mtext>
+                          </mtd>
+                        </mtr>
+                      </mtable>
+                    </math>
+
+                    Rounding up to the nearest power of two gives a conservative estimate of 65,536 fifty millisecond intervals, so we want to give progress to 1 part in 2<sup>16</sup>.
+                  </details>
+                </div>
+
+              1. If |progressFraction| is not equal to |lastProgressFraction|, then perform |fireProgressEvent| given |progressFraction|.
+
+              1. If |bytesSoFar| equals |totalBytes|, then [=iteration/break=].
+
+                <p class="note">Since this is the only exit condition for the loop, we are guaranteed to fire a {{AICreateMonitor/downloadprogress}} event for the 100% mark.</p>
+
+              1. Set |lastProgressFraction| to |progressFraction|.
+
+              1. Set |lastProgressTime| to the [=monotonic clock=]'s [=monotonic clock/unsafe current time=].
 
         1. [=If aborted=], then:
 

--- a/index.bs
+++ b/index.bs
@@ -861,6 +861,14 @@ enum AIRewriterLength { "as-is", "shorter", "longer" };
 
           1. Wait for the total number of bytes to be downloaded to become determined, and let that number be |totalBytes|.
 
+             This number must be equal to the number of bytes that the user agent needs to download at the present time, not including any that have already been downloaded.
+
+             <div class="note">
+              <p>For example, if another tab has started the download and it is 90% finished, and the user agent is planning to share the model across all tabs, then |totalBytes| will be 10% of the size of the model, not 100% of the size of the model.
+
+              <p>This prevents the web developer-perceived progress from suddenly jumping from 0% to 90%, and then taking a long time to go from 90% to 100%. It also provides some protection against the (admittedly not very powerful) fingerprinting vector of measuring the current download progress across multiple sites.
+             </div>
+
           1. Let |lastProgressFraction| be 0.
 
           1. Let |lastProgressTime| be the [=monotonic clock=]'s [=monotonic clock/unsafe current time=].


### PR DESCRIPTION
Closes #41.

@nathanmemmott @lozy219 please take a look! (The diff is probably more readable if you turn off whitespace diffing, or maybe just look at the preview output side by side with the old one.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/pull/42.html" title="Last updated on Feb 26, 2025, 5:01 AM UTC (e2d7b83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/42/41216b3...e2d7b83.html" title="Last updated on Feb 26, 2025, 5:01 AM UTC (e2d7b83)">Diff</a>