### PR TITLE
Fix broken "compute language availability" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2358,6 +2358,8 @@ A <dfn>language availabilities triple</dfn> is a [=struct=] with the following [
 
   1. [=set/For each=] |language| of |requestedLanguages|:
 
+    1. Let |unavailable| be true.
+
     1. [=list/For each=] |availabilityToCheck| of « "{{Availability/available}}", "{{Availability/downloading}}", "{{Availability/downloadable}}" »:
 
       1. Let |languagesWithThisAvailability| be |partition|[|availabilityToCheck|].
@@ -2370,9 +2372,11 @@ A <dfn>language availabilities triple</dfn> is a [=struct=] with the following [
 
         1. Set |availability| to the [=Availability/minimum availability=] given |availability| and |availabilityToCheck|.
 
+        1. Set |unavailable| to false.
+
         1. [=iteration/Break=].
 
-    1. Return "{{Availability/unavailable}}".
+    1. If |unavailable| is true, then return "{{Availability/unavailable}}".
 
   1. Return |availability|.
 </div>


### PR DESCRIPTION
The intention is to get the minimum availability over all languages, so we return "unavailable" the first time we encounter an unavailable language.

Closes #58. @nathanmemmott PTAL!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/pull/59.html" title="Last updated on Apr 16, 2025, 2:18 AM UTC (e3d29c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/59/5c4116c...e3d29c0.html" title="Last updated on Apr 16, 2025, 2:18 AM UTC (e3d29c0)">Diff</a>