### PR TITLE
Update QuotaExceededError references

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If the `outputLanguage` is not supplied, the default behavior is to produce the 
 
 It's possible that the inputs given for summarizing and rewriting might be too large for the underlying machine learning model to handle. The same can even be the case for strings that are usually smaller, such as the writing task for the writer API, or the context given to all APIs.
 
-Whenever any API call fails due to too-large input, it is rejected with a `QuotaExceededError`. This is a proposed new type of exception, which subclasses `DOMException`, and replaces the web platform's existing `"QuotaExceededError"` `DOMException`. See [whatwg/webidl#1465](https://github.com/whatwg/webidl/pull/1465) for this proposal. For our purposes, the important part is that it has the following properties:
+Whenever any API call fails due to too-large input, it is rejected with a `QuotaExceededError`, with the following properties:
 
 * `requested`: how many tokens the input consists of
 * `quota`: how many tokens were available (which will be less than `requested`)

--- a/index.bs
+++ b/index.bs
@@ -31,12 +31,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
     text: floor; url: eqn-floor
   type: dfn
     text: current realm; url: current-realm
-urlPrefix: https://whatpr.org/webidl/1465.html; spec: WEBIDL
-  type: interface
-    text: QuotaExceededError; url: quotaexceedederror
-  type: dfn; for: QuotaExceededError
-    text: requested; url: quotaexceedederror-requested
-    text: quota; url: quotaexceedederror-quota
 </pre>
 
 <style>
@@ -2402,8 +2396,6 @@ A <dfn export>quota exceeded error information</dfn> is a [=struct=] with the fo
 :: a number that will be used for the {{QuotaExceededError}}'s [=QuotaExceededError/requested=].
 : <dfn export for="quota exceeded error information">quota</dfn>
 :: a number that will be used for the {{QuotaExceededError}}'s [=QuotaExceededError/quota=].
-
-<p class="advisement">The parts of this specification related to quota exceeded errors assume that <a href="https://github.com/whatwg/webidl/pull/1465">whatwg/webidl#1465</a> will be merged.
 
 <div algorithm>
   To <dfn export>convert error information into an exception object</dfn>, given an [=error information=] |errorInfo|:


### PR DESCRIPTION
Once https://github.com/whatwg/webidl/pull/1465 is merged, we can reference Web IDL directly, instead of the pull request preview.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/pull/72.html" title="Last updated on Jul 8, 2025, 4:25 AM UTC (ef8f5d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/72/5ce8832...ef8f5d9.html" title="Last updated on Jul 8, 2025, 4:25 AM UTC (ef8f5d9)">Diff</a>