### PR TITLE
Relax user activation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1834,7 +1834,7 @@ Every [=interface=] [=interface/including=] the {{DestroyableModel}} interface m
               1. Abort these steps.
 
             1. [=Consume user activation=] given |realm|'s [=realm/global object=].
-          1. Else:
+          1. Otherwise:
             1. If |realm|'s [=realm/global object=] does not have [=sticky activation=], then:
 
               1. [=Queue a global task=] on the [=AI task source=] given |realm|'s [=realm/global object=] to [=reject=] |promise| with a "{{NotAllowedError}}" {{DOMException}}.


### PR DESCRIPTION
Relax user activation requirements for session creation

This change updates the specification to require sticky user activation
instead of transient user activation for creating sessions under
certain conditions, as discussed in issue #83.

Fixes: https://github.com/webmachinelearning/writing-assistance-apis/issues/83


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/isaacahouma/writing-assistance-apis/pull/86.html" title="Last updated on Oct 30, 2025, 4:39 PM UTC (e3664f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/86/d759046...isaacahouma:e3664f9.html" title="Last updated on Oct 30, 2025, 4:39 PM UTC (e3664f9)">Diff</a>