### PR TITLE
Add Reilly as the editor, retire Domenic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,8 @@ Status: CG-DRAFT
 Group: webml
 Repository: webmachinelearning/writing-assistance-apis
 URL: https://webmachinelearning.github.io/writing-assistance-apis
-Editor: Domenic Denicola, Google https://www.google.com/, d@domenic.me, https://domenic.me/
+Editor: Reilly Grant 83788, Google https://www.google.com, reillyg@google.com
+Former editor: Domenic Denicola 52873, Google https://www.google.com/, d@domenic.me, https://domenic.me/
 Abstract: The summarizer, writer, and rewriter APIs provide high-level interfaces to call on a browser or operating system's built-in language model to help with writing tasks.
 Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 yes, missing-example-ids yes


### PR DESCRIPTION
With Domenic departing Google he is stepping down from his role as editor of this specification. We thank him for his service to the web community in this and all of his other work over the years.

With the Chair's permission I nominate myself to take over the role of editor for this specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/writing-assistance-apis/pull/87.html" title="Last updated on Oct 28, 2025, 8:13 PM UTC (4d50114)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/writing-assistance-apis/87/d759046...reillyeon:4d50114.html" title="Last updated on Oct 28, 2025, 8:13 PM UTC (4d50114)">Diff</a>