### PR TITLE
Clarify create algorithm description parameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1745,7 +1745,8 @@ Every [=interface=] [=interface/including=] the {{DestroyableModel}} interface m
   * an algorithm |getAvailability| taking an [=ordered map=] and returning an {{Availability}} or null,
   * an algorithm |startDownload| taking an [=ordered map=] and returning a boolean,
   * an algorithm |initialize| taking an [=ordered map=] and returning an error information or null, and
-  * an algorithm |create| taking a [=ECMAScript/realm=], an [=ordered map=] and an optional boolean |requireTransientActivation| (default true) and returning a Web IDL object representing the model,
+  * an algorithm |create| taking a [=ECMAScript/realm=], an [=ordered map=] and returning a Web IDL object representing the model, and
+  * an optional boolean |requireTransientActivation| (default true).
 
   perform the following steps:
 


### PR DESCRIPTION
requireTransientActivation is a parameter to the "create an AI model object" algorithm, not a parameter to the create algorithm that must be passed to it.