### PR TITLE
Add clarifications to Summarizer preference parameter

### DIFF
--- a/explainers/summarizer-preference-param.md
+++ b/explainers/summarizer-preference-param.md
@@ -31,6 +31,13 @@ dictionary SummarizerCreateCoreOptions {
 *   **`"speed"`:** The implementation should prioritize low latency and fast execution. This approach prioritizes performance, which may limit the summarization capability, potentially resulting in less nuanced extraction or simpler synthesis of the source text.
 *   **`"capability"`:** The implementation should prioritize the comprehensiveness and coherence of the summarization, and a model that offers more flexibility in terms of summary types and other configurable options. This approach focuses on accurately capturing subtle context and producing highly refined summaries, which may result in higher latency and slower execution speeds.
 
+## Conflicting Constraints and Routing Fallbacks
+The preference parameter acts as a strong hint to the implementation, rather than a strict guarantee. In scenarios where a developer's performance preference conflicts with a hard functional requirement, the implementation should prioritize the functional requirement.
+
+For example, if an implementation has a smaller, fast model that only supports English (ideal for "speed") and a larger model that supports multiple languages (ideal for "capability"):
+
+If a developer requests preference: "speed" but requires French language support, the implementation will route the request to the larger model. It prioritizes successfully completing the task in the required language over the developer's preference for lower latency.
+
 ## Application to Other APIs
 
 The `preference` parameter addresses a fundamental tradeoff that exists across all client-side machine learning tasks. As such, it is applicable to other APIs in the built-in AI ecosystem.

--- a/explainers/summarizer-preference-param.md
+++ b/explainers/summarizer-preference-param.md
@@ -27,16 +27,18 @@ dictionary SummarizerCreateCoreOptions {
 };
 ```
 
-*   **`"auto"`:** It is implementation-defined how to balance execution speed with summarization capability. The implementation may dynamically adjust its internal processing based on the user agent's environment, system constraints, or context.
-*   **`"speed"`:** The implementation should prioritize low latency and fast execution. This approach prioritizes performance, which may limit the summarization capability, potentially resulting in less nuanced extraction or simpler synthesis of the source text.
-*   **`"capability"`:** The implementation should prioritize the comprehensiveness and coherence of the summarization, and a model that offers more flexibility in terms of summary types and other configurable options. This approach focuses on accurately capturing subtle context and producing highly refined summaries, which may result in higher latency and slower execution speeds.
+*   **`"auto"`:** It is implementation-defined how to balance execution speed with summarization capability. The implementation MAY dynamically adjust its internal processing based on the user agent's environment, system constraints, or context.
+*   **`"speed"`:** The implementation SHOULD prioritize low latency and fast execution. This approach prioritizes performance, which may limit the summarization capability, potentially resulting in less nuanced extraction or simpler synthesis of the source text.
+*   **`"capability"`:** The implementation SHOULD prioritize the comprehensiveness and coherence of the summarization, and a model that offers more flexibility in terms of summary types and other configurable options. This approach focuses on accurately capturing subtle context and producing highly refined summaries, which may result in higher latency and slower execution speeds.
 
 ## Conflicting Constraints and Routing Fallbacks
-The preference parameter acts as a strong hint to the implementation, rather than a strict guarantee. In scenarios where a developer's performance preference conflicts with a hard functional requirement, the implementation should prioritize the functional requirement.
+The preference parameter acts as a strong hint to the implementation, rather than a strict guarantee. In scenarios where a developer's performance preference conflicts with a hard functional requirement, the implementation MUST prioritize the functional requirement.
 
-For example, if an implementation has a smaller, fast model that only supports English (ideal for "speed") and a larger model that supports multiple languages (ideal for "capability"):
+For example, if an implementation has a smaller, fast model that only supports English and a larger model that supports multiple languages:
 
 If a developer requests preference: "speed" but requires French language support, the implementation will route the request to the larger model. It prioritizes successfully completing the task in the required language over the developer's preference for lower latency.
+
+Beyond hard functional requirements, we hope to explore whether other dynamic factors might play into how implementations honor the preference. For example, a user agent might consider current device resource usage (such as battery status or memory pressure) when deciding which model to route to, potentially deviating from the developer's preference to ensure system stability.
 
 ## Application to Other APIs
 

--- a/index.bs
+++ b/index.bs
@@ -68,6 +68,7 @@ interface Summarizer {
   readonly attribute SummarizerType type;
   readonly attribute SummarizerFormat format;
   readonly attribute SummarizerLength length;
+  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
   readonly attribute PerformancePreference preference;
 
   readonly attribute FrozenArray<DOMString>? expectedInputLanguages;
@@ -86,6 +87,7 @@ dictionary SummarizerCreateCoreOptions {
   SummarizerType type = "key-points";
   SummarizerFormat format = "markdown";
   SummarizerLength length = "short";
+  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
   PerformancePreference preference = "auto";
 
   sequence<DOMString> expectedInputLanguages;
@@ -625,6 +627,8 @@ This section gives normative guidance on how the implementation of [=summarize=]
       <td>
         <p>The implementation should prioritize the comprehensiveness and coherence of the summarization. This approach focuses on accurately capturing subtle context and producing highly refined summaries, which may result in higher latency and slower execution speeds.</p>
 </table>
+
+<p class="note">When resolving the underlying model, the implementation should prioritize hard functional constraints over the <code>preference</code> hint. For example, if the requested options require specific capabilities (such as a requested language in <code>expectedInputLanguages</code>) that are only supported by a model that does not align with the requested <code>preference</code>, the implementation should select the model capable of completing the task.</p>
 
 <p class="note">As with all "<span class="allow-2119">should</span>"-level guidance, user agents might not conform perfectly to these. Especially in the case of counting words, it's expected that language models might not conform perfectly.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 17, 2026, 2:08 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fjaewon078%2Fwriting-assistance-apis%2Fed7bbe0055ffe927a67b3be92f84a09b40b6c435%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2293:91",
        "messageType": "link",
        "text": "Multiple possible 'RangeError' idl refs.\nArbitrarily chose https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-rangeerror\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:ecmascript; type:exception; text:RangeError\nspec:webidl; type:exception; text:RangeError\n{{RangeError}}"
    },
    {
        "lineNum": "631:1",
        "messageType": "lint",
        "text": "RFC2119 keyword in non-normative section (use: might, can, has to, or override with <span class=allow-2119>): When resolving the underlying model, the implementation should prioritize hard functional constraints over the \n<p bs-line-number=\"631:1\" class=\"note\">When resolving the underlying model, the implementation should prioritize hard functional constraints over the <code bs-line-number=\"631:128\">preference</code> hint. For example, if the requested options require specific capabilities (such as a requested language in <code bs-line-number=\"631:259\">expectedInputLanguages</code>) that are only supported by a model that does not align with the requested <code bs-line-number=\"631:370\">preference</code>, the implementation should select the model capable of completing the task.</p>"
    },
    {
        "lineNum": "631:1",
        "messageType": "lint",
        "text": "RFC2119 keyword in non-normative section (use: might, can, has to, or override with <span class=allow-2119>): , the implementation should select the model capable of completing the task.\n<p bs-line-number=\"631:1\" class=\"note\">When resolving the underlying model, the implementation should prioritize hard functional constraints over the <code bs-line-number=\"631:128\">preference</code> hint. For example, if the requested options require specific capabilities (such as a requested language in <code bs-line-number=\"631:259\">expectedInputLanguages</code>) that are only supported by a model that does not align with the requested <code bs-line-number=\"631:370\">preference</code>, the implementation should select the model capable of completing the task.</p>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20webmachinelearning/writing-assistance-apis%23102.)._

</details>
